### PR TITLE
Update Dockerfile to base FROM Centos node4 image

### DIFF
--- a/fh-statsd/docker/Dockerfile
+++ b/fh-statsd/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhscl/nodejs-4-rhel7
+FROM centos/nodejs-4-centos7
 
 EXPOSE 8080
 

--- a/fh-statsd/npm-shrinkwrap.json
+++ b/fh-statsd/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-statsd",
-  "version": "2.0.3-BUILD-NUMBER",
+  "version": "2.0.4-BUILD-NUMBER",
   "dependencies": {
     "async": {
       "version": "0.1.18",

--- a/fh-statsd/package.json
+++ b/fh-statsd/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-statsd",
   "description": "FeedHenry Stats Server",
-  "version": "2.0.3-BUILD-NUMBER",
+  "version": "2.0.4-BUILD-NUMBER",
   "repository": {
     "type": "git",
     "url": "amz1svn1.feedhenry.com:/var/git/fh-stats.git"

--- a/fh-statsd/sonar-project.properties
+++ b/fh-statsd/sonar-project.properties
@@ -1,3 +1,3 @@
 sonar.projectKey=fh-statsd
 sonar.projectName=fh-statsd-nightly_master
-sonar.projectVersion=2.0.3
+sonar.projectVersion=2.0.4


### PR DESCRIPTION
Since Open sourcing this project we no longer want to inherit from RHEL image where user would need subscription in place to pull the Docker image.