### PR TITLE
removed kernel headers dockerfile

### DIFF
--- a/fh-statsd/docker/Dockerfile
+++ b/fh-statsd/docker/Dockerfile
@@ -6,7 +6,8 @@ USER root
 
 RUN ln -sf /usr/share/zoneinfo/UTC /etc/localtime && \
     mkdir -p config && \
-    chown -R default:root ./
+    chown -R default:root ./ && \
+    yum -y remove kernel-headers 
 
 USER default
 


### PR DESCRIPTION
https://issues.jboss.org/browse/RHMAP-17576

Verification:  Run the docker container locally and bash into it.  ```docker run -it IMAGE_NAME /bin/bash```
In the container run ``` yum list installed "kernel*"```
Ensure that no package is listed with kernel in it