### PR TITLE
Rhmap 20884

### DIFF
--- a/fh-statsd/Dockerfile.dev
+++ b/fh-statsd/Dockerfile.dev
@@ -16,10 +16,12 @@ RUN ln -sf /usr/share/zoneinfo/UTC /etc/localtime && \
 
 USER default
 
-RUN scl enable rh-nodejs6 "npm install -g nodemon" && \
+RUN scl enable rh-nodejs6 "npm install -g forever" && \
     scl enable rh-nodejs6 "npm install --production" && \
     mv conf-docker.json config/conf.json && \
     chmod -R ug+rw ./
+
+RUN echo "node_modules" >> .foreverignore
 
 USER root
 RUN  mkdir -p /root/licenses/rhmap/ && \
@@ -27,4 +29,4 @@ RUN  mkdir -p /root/licenses/rhmap/ && \
 USER default
 
 ENV FHDEV true
-CMD ["bash", "-c", "nodemon --debug=5858 bin/fh-statsd.js config/conf.json --master-only"]
+CMD ["forever","-w","--watchDirectory=/opt/app-root/src", "-c", "node --debug", "bin/fh-statsd.js","config/conf.json","--master-only"]

--- a/fh-statsd/README.md
+++ b/fh-statsd/README.md
@@ -60,6 +60,7 @@ For development purposes, we can build a CentOS based Docker image and watch for
 ### Build the development image
 1. Generate the config file: `grunt fh-generate-dockerised-config`
 2. `docker build -t docker.io/my-Username/fh-statsd:dev -f Dockerfile.dev .`
+1. `docker push docker.io/my-Username/fh-statsd:dev`
 3. `oc edit dc fh-statsd`
 4. Replace the image with the tagged version above.
 
@@ -68,7 +69,7 @@ For development purposes, we can build a CentOS based Docker image and watch for
 The development image will allow you to sync local code changes to the running container without the need for rebuilding or redeploying the image.
 
 From the root of the `fh-statsd directory, run the following:
-```oc rsync --no-perms=true ./lib $(oc get po | grep fh-statsd | grep Running | awk '{print $1}'):/opt/app-root/src ```
+```oc rsync --no-perms=true --watch ./lib $(oc get po | grep fh-statsd | grep Running | awk '{print $1}'):/opt/app-root/src ```
 
 ### Debugging with VS Code
 


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/RHMAP-20884
https://issues.jboss.org/browse/RHMAP-20593


# What
Update Dockerfile.dev to use forever npm
Fixing the CMD in the Dockerfile.dev to run this component in debug mode. 


# Why
Having the component run in debug mode allows us to attach a remote debugger (e.g. from VS Code).


# How
When using the forever module, running node in debug mode requires the command to be specified like so `-c "node --debug"`


# Verification Steps
1. Go to https://csteam1.skunkhenry.com:8443/console/project/rhmap-3-node-mbaas/browse/pods/fh-statsd-2-z7bsc?tab=logs
3. Verify that the top of the logs says `Debugger listening on [::]:5858`


## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 